### PR TITLE
Report upload progress from the main thread

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if sys.version_info[0] < 3:
 
 setuptools.setup(
     name="pyodm",
-    version="1.5.2b1",
+    version="1.5.3",
     author="OpenDroneMap Contributors",
     author_email="pt@masseranolabs.com",
     description="Python SDK for OpenDroneMap",


### PR DESCRIPTION
This is going to make it easier for client applications like WebODM to report progress updates without having to deal with threading problems.