### PR TITLE
Fix hangs on chunked downloads

### DIFF
--- a/pyodm/api.py
+++ b/pyodm/api.py
@@ -642,7 +642,7 @@ class Task:
                     range_start = range_end + 1
 
                 # block until all tasks are done
-                while not q.empty() and nonloc.error is None:
+                while not all(nonloc.merge_chunks) and nonloc.error is None:
                     time.sleep(0.1)
 
                 # stop workers

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if sys.version_info[0] < 3:
 
 setuptools.setup(
     name="pyodm",
-    version="1.5.5",
+    version="1.5.6",
     author="OpenDroneMap Contributors",
     author_email="pt@uav4geo.com",
     description="Python SDK for OpenDroneMap",


### PR DESCRIPTION
In certain cases, when one of the last chunks fails to download (due to the server reporting the wrong number of bytes), the stop workers code would execute before the failed chunk gets a chance to be retried. This dooms the code to an infinite loop, since the merge thread continues waiting for the last chunk to be finished (but never completes, because the worker threads have been teared down already).
﻿
