### PR TITLE
Added a check for noRetry, received from NodeODM response, so that retrying is stopped in non-recoverability cases

### DIFF
--- a/pyodm/api.py
+++ b/pyodm/api.py
@@ -318,7 +318,7 @@ class Node:
                             else:
                                 raise NodeServerError("Failed upload with unexpected result: %s" % str(result))
                     except OdmError as e:
-                        if task['retries'] < max_retries:
+                        if task['retries'] < max_retries and not (isinstance(result, dict) and 'noRetry' in result and result['noRetry']):
                             # Put task back in queue
                             task['retries'] += 1
                             task['wait_until'] = datetime.datetime.now() + datetime.timedelta(seconds=task['retries'] * retry_timeout)


### PR DESCRIPTION
Fixes #16 

This PR initiates the idea to add this check across appropriate places to stop retrying uploading in case of non-recoverable failure. 
_I'll also make a PR at NodeODM so that_ `noRetry: True` _is returned when NodeODM runs into a non-recoverable error_