### PR TITLE
Support for image URLs with access tokens

### DIFF
--- a/pyodm/api.py
+++ b/pyodm/api.py
@@ -47,7 +47,7 @@ class Node:
     prefixHttp = re.compile('http:', re.I)
     prefixHttps = re.compile('https:', re.I)
 
-    presignedURL = re.compile("/?AWSAccessKeyId", re.I)
+    presignedURL = re.compile("\.[a-z]*\?", re.I)
 
     def __init__(self, host, port, token="", timeout=30):
         self.host = host

--- a/pyodm/api.py
+++ b/pyodm/api.py
@@ -303,9 +303,8 @@ class Node:
 
                     try:
                         file = task['file']
-                        # Check if the object url is presigned
+                        # Check if the object url contains an access token
                         if Node.presignedURL.search(file) is not None:
-                            # If the url is presigned
                             fields = {
                                 'images': [(os.path.basename(file.split("?")[0]), read_file(file), (mimetypes.guess_type(file)[0] or "image/jpg"))]
                             }


### PR DESCRIPTION
Added a regex to identify access tokens appended to image URLs. If found, the image filename is extracted from the URL accordingly.