### PR TITLE
Initialize 'result' variable to prevent UnboundLocalError (Fixes #27)

### DIFF
--- a/pyodm/api.py
+++ b/pyodm/api.py
@@ -300,7 +300,9 @@ class Node:
                     # Upload file
                     if task['wait_until'] > datetime.datetime.now():
                         time.sleep((task['wait_until'] - datetime.datetime.now()).seconds)
-
+                    
+                    # Assign value to result, prevent UnboundLocalError
+                    result = None
                     try:
                         file = task['file']
                         # Check if the object url contains an access token


### PR DESCRIPTION
This commit addresses the UnboundLocalError in the worker function by initializing the 'result' variable before the try-except block. This ensures that 'result' is always defined, avoiding the error when it's referenced in the except block.

- Declared 'result' with a default value of None prior to the try block.
- Ensures 'result' is available for the conditional check in the exception handling.