### PR TITLE
avoid WinEError 32 errors caused by resources not being freed yet

### DIFF
--- a/pyodm/api.py
+++ b/pyodm/api.py
@@ -709,7 +709,7 @@ class Task:
         zip_path = self.download_zip(destination, progress_callback=progress_callback, parallel_downloads=parallel_downloads, parallel_chunks_size=parallel_chunks_size)
         with zipfile.ZipFile(zip_path, "r") as zip_h:
             zip_h.extractall(destination)
-            os.remove(zip_path)
+        os.remove(zip_path)
 
         return destination
 


### PR DESCRIPTION
When attempting to download assets, I get a WinError 32 error which I believe is caused by the zip file not being freed by Python yet. This is because the `with` block still has a hold on the file. Moving the remove logic outside this block fixes the issue.


Code used:

```
import os
from pyodm import Node


n = Node('localhost', 3020)
task = n.create_task(['examples/images/image_1.jpg', 'examples/images/image_2.jpg'], {'dsm': True})
task.wait_for_completion()

os.listdir(task.download_assets("results"))[0:2]
```

Error:
`PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'results\\xxxxxx_all.zip'`